### PR TITLE
feat: Enhance service reliability, persistence, and Windows client st…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,8 @@
             android:name=".MyVpnServiceTun2Socks"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:foregroundServiceType="specialUse"
-            android:exported="false">
+            android:exported="false"
+            android:process=":vpn">    <!-- ADD THIS LINE -->
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
@@ -66,6 +67,15 @@
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="VPN proxy for hotspot bypass" />
         </service>
+
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <!-- In AndroidManifest.xml -->
         <service

--- a/app/src/main/java/com/example/hotspot_bypass_vpn/BootReceiver.kt
+++ b/app/src/main/java/com/example/hotspot_bypass_vpn/BootReceiver.kt
@@ -1,0 +1,27 @@
+package com.example.hotspot_bypass_vpn
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            // Only restart if the services were previously running
+            // You could persist this preference in SharedPreferences
+            val prefs = context.getSharedPreferences("bypass_vpn_prefs", Context.MODE_PRIVATE)
+            val wasHostRunning = prefs.getBoolean("host_was_running", false)
+            val wasVpnRunning = prefs.getBoolean("vpn_was_running", false)
+
+            if (wasHostRunning) {
+                val hostIntent = Intent(context, HostService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(hostIntent)
+                } else {
+                    context.startService(hostIntent)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/hotspot_bypass_vpn/HostService.kt
+++ b/app/src/main/java/com/example/hotspot_bypass_vpn/HostService.kt
@@ -10,6 +10,9 @@ import android.net.wifi.p2p.WifiP2pManager
 import android.os.*
 import androidx.core.app.NotificationCompat
 import android.util.Log
+import android.os.SystemClock
+import android.app.AlarmManager
+import android.app.PendingIntent
 
 class HostService : Service() {
 
@@ -113,8 +116,65 @@ class HostService : Service() {
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        // Keeps service alive when swiped away
-        Log.d("HostService", "App swiped, service continuing...")
+        Log.d("HostService", "App swiped — scheduling restart...")
+        val restartIntent = Intent(applicationContext, HostService::class.java).apply {
+            putExtra("WIFI_BAND", preferredBand)
+        }
+        val pendingIntent = PendingIntent.getService(
+            applicationContext, 1, restartIntent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val triggerTime = SystemClock.elapsedRealtime() + 1000L
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (alarmManager.canScheduleExactAlarms()) {
+                    alarmManager.setExactAndAllowWhileIdle(
+                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                        triggerTime,
+                        pendingIntent
+                    )
+                } else {
+                    // Fallback to inexact alarm if permission is denied
+                    alarmManager.setAndAllowWhileIdle(
+                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                        triggerTime,
+                        pendingIntent
+                    )
+                }
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.set(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            }
+        } catch (e: SecurityException) {
+            Log.e("HostService", "Exact alarm permission missing, using inexact fallback", e)
+            // Safety fallback for unexpected cases
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.set(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            }
+        }
+
+        super.onTaskRemoved(rootIntent)
     }
 
     private fun createNotification(content: String): Notification {

--- a/app/src/main/java/com/example/hotspot_bypass_vpn/MainActivity.kt
+++ b/app/src/main/java/com/example/hotspot_bypass_vpn/MainActivity.kt
@@ -641,6 +641,7 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
             isHostRunning.value = true
             logState.add("Starting Host Service...")
         }
+        saveServiceState(hostRunning = true)
     }
 
     private fun handleStopHost() {
@@ -649,10 +650,15 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
         hostInfoState.value = null
         isHostRunning.value = false
         logState.add("Host Service Stopped.")
+        saveServiceState(hostRunning = false)
     }
 
     private fun handleConnectClient() {
         if (checkHardwareStatus()) {
+            if (!isIgnoringBatteryOptimizations()) {
+                requestIgnoreBatteryOptimizations()
+                return
+            }
             if (getPrivateDnsMode() == "hostname") {
                 Toast.makeText(this, "Disable Private DNS first!", Toast.LENGTH_LONG).show()
                 navigateToPrivateDnsSettings()
@@ -667,6 +673,9 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
         startService(intent)
         isClientRunning.value = false
         logState.add("VPN Client Stopped.")
+
+        // FIX: Use vpnRunning = false
+        saveServiceState(vpnRunning = false)
     }
 
     private fun startVpnService(ip: String, port: Int) {
@@ -681,6 +690,9 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
         }
         isClientRunning.value = true
         logState.add("VPN Client Starting...")
+
+        // FIX: Use vpnRunning instead of hostRunning
+        saveServiceState(vpnRunning = true)
     }
 
     override fun onConnectionInfoAvailable(info: WifiP2pInfo?) {
@@ -812,6 +824,15 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
             } catch (e: SecurityException) {
                 logState.add("Sync error: Permission denied")
             }
+        }
+    }
+
+    private fun saveServiceState(hostRunning: Boolean? = null, vpnRunning: Boolean? = null) {
+        val prefs = getSharedPreferences("bypass_vpn_prefs", Context.MODE_PRIVATE)
+        prefs.edit().apply {
+            hostRunning?.let { putBoolean("host_was_running", it) }
+            vpnRunning?.let { putBoolean("vpn_was_running", it) }
+            apply()
         }
     }
 }

--- a/app/src/main/java/com/example/hotspot_bypass_vpn/Myvpnservicetun2socks.kt
+++ b/app/src/main/java/com/example/hotspot_bypass_vpn/Myvpnservicetun2socks.kt
@@ -1,12 +1,14 @@
 package com.example.hotspot_bypass_vpn
 
+import android.app.AlarmManager
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.VpnService
-import android.os.Build
-import android.os.ParcelFileDescriptor
+import android.net.wifi.WifiManager
+import android.os.*
 import androidx.core.app.NotificationCompat
 import engine.Engine
 import kotlin.concurrent.thread
@@ -17,10 +19,27 @@ class MyVpnServiceTun2Socks : VpnService() {
     private var isRunning = false
     private var proxyIp = ""
     private var proxyPort = 0
+    private var wakeLock: PowerManager.WakeLock? = null
+    private var wifiLock: WifiManager.WifiLock? = null
 
     companion object {
         const val ACTION_STOP = "com.example.hotspot_bypass_vpn.STOP"
         var isServiceRunning = false // ADD THIS
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        acquireLocks()
+    }
+
+    private fun acquireLocks() {
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "BypassVPN::VpnWakeLock")
+        wakeLock?.acquire()
+
+        val wm = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "BypassVPN::VpnWifiLock")
+        wifiLock?.acquire()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -206,9 +225,34 @@ class MyVpnServiceTun2Socks : VpnService() {
         getSystemService(NotificationManager::class.java).notify(1, notification)
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        DebugUtils.log("App swiped — scheduling VPN restart...")
+        val restartIntent = Intent(applicationContext, MyVpnServiceTun2Socks::class.java).apply {
+            putExtra("PROXY_IP", proxyIp)
+            putExtra("PROXY_PORT", proxyPort)
+        }
+        val pendingIntent = PendingIntent.getService(
+            applicationContext, 2, restartIntent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val triggerTime = SystemClock.elapsedRealtime() + 1000L
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, pendingIntent)
+        } else {
+            alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, pendingIntent)
+        }
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onDestroy() {
         DebugUtils.log("CRITICAL: Executing Stop Sequence...")
         isServiceRunning = false // SET FALSE
+
+        // Release locks
+        wakeLock?.let { if (it.isHeld) it.release() }
+        wifiLock?.let { if (it.isHeld) it.release() }
 
         // 1. FORCIBLY close the VPN Interface first
         // This tells the Android OS to immediately remove the VPN routes

--- a/full_context_part1.txt
+++ b/full_context_part1.txt
@@ -161,7 +161,8 @@ FILE: app\src\main\AndroidManifest.xml
             android:name=".MyVpnServiceTun2Socks"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:foregroundServiceType="specialUse"
-            android:exported="false">
+            android:exported="false"
+            android:process=":vpn">    <!-- ADD THIS LINE -->
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
@@ -185,6 +186,15 @@ FILE: app\src\main\AndroidManifest.xml
                 android:value="VPN proxy for hotspot bypass" />
         </service>
 
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
         <!-- In AndroidManifest.xml -->
         <service
             android:name=".HostService"
@@ -200,6 +210,38 @@ FILE: app\src\main\AndroidManifest.xml
     </application>
 
 </manifest>
+
+============================================================
+FILE: app\src\main\java\com\example\hotspot_bypass_vpn\BootReceiver.kt
+============================================================
+
+package com.example.hotspot_bypass_vpn
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            // Only restart if the services were previously running
+            // You could persist this preference in SharedPreferences
+            val prefs = context.getSharedPreferences("bypass_vpn_prefs", Context.MODE_PRIVATE)
+            val wasHostRunning = prefs.getBoolean("host_was_running", false)
+            val wasVpnRunning = prefs.getBoolean("vpn_was_running", false)
+
+            if (wasHostRunning) {
+                val hostIntent = Intent(context, HostService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(hostIntent)
+                } else {
+                    context.startService(hostIntent)
+                }
+            }
+        }
+    }
+}
 
 ============================================================
 FILE: app\src\main\java\com\example\hotspot_bypass_vpn\DebugUtils.kt
@@ -365,6 +407,9 @@ import android.net.wifi.p2p.WifiP2pManager
 import android.os.*
 import androidx.core.app.NotificationCompat
 import android.util.Log
+import android.os.SystemClock
+import android.app.AlarmManager
+import android.app.PendingIntent
 
 class HostService : Service() {
 
@@ -468,8 +513,63 @@ class HostService : Service() {
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        // Keeps service alive when swiped away
-        Log.d("HostService", "App swiped, service continuing...")
+        Log.d("HostService", "App swiped — scheduling restart...")
+        val restartIntent = Intent(applicationContext, HostService::class.java)
+        val pendingIntent = PendingIntent.getService(
+            applicationContext, 1, restartIntent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val triggerTime = SystemClock.elapsedRealtime() + 1000L
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (alarmManager.canScheduleExactAlarms()) {
+                    alarmManager.setExactAndAllowWhileIdle(
+                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                        triggerTime,
+                        pendingIntent
+                    )
+                } else {
+                    // Fallback to inexact alarm if permission is denied
+                    alarmManager.setAndAllowWhileIdle(
+                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                        triggerTime,
+                        pendingIntent
+                    )
+                }
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.set(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            }
+        } catch (e: SecurityException) {
+            Log.e("HostService", "Exact alarm permission missing, using inexact fallback", e)
+            // Safety fallback for unexpected cases
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.set(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    triggerTime,
+                    pendingIntent
+                )
+            }
+        }
+
+        super.onTaskRemoved(rootIntent)
     }
 
     private fun createNotification(content: String): Notification {
@@ -1170,6 +1270,7 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
             isHostRunning.value = true
             logState.add("Starting Host Service...")
         }
+        saveServiceState(hostRunning = true)
     }
 
     private fun handleStopHost() {
@@ -1178,6 +1279,7 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
         hostInfoState.value = null
         isHostRunning.value = false
         logState.add("Host Service Stopped.")
+        saveServiceState(hostRunning = false)
     }
 
     private fun handleConnectClient() {
@@ -1196,6 +1298,9 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
         startService(intent)
         isClientRunning.value = false
         logState.add("VPN Client Stopped.")
+
+        // FIX: Use vpnRunning = false
+        saveServiceState(vpnRunning = false)
     }
 
     private fun startVpnService(ip: String, port: Int) {
@@ -1210,6 +1315,9 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
         }
         isClientRunning.value = true
         logState.add("VPN Client Starting...")
+
+        // FIX: Use vpnRunning instead of hostRunning
+        saveServiceState(vpnRunning = true)
     }
 
     override fun onConnectionInfoAvailable(info: WifiP2pInfo?) {
@@ -1341,6 +1449,15 @@ class MainActivity : ComponentActivity(), WifiP2pManager.ConnectionInfoListener 
             } catch (e: SecurityException) {
                 logState.add("Sync error: Permission denied")
             }
+        }
+    }
+
+    private fun saveServiceState(hostRunning: Boolean? = null, vpnRunning: Boolean? = null) {
+        val prefs = getSharedPreferences("bypass_vpn_prefs", Context.MODE_PRIVATE)
+        prefs.edit().apply {
+            hostRunning?.let { putBoolean("host_was_running", it) }
+            vpnRunning?.let { putBoolean("vpn_was_running", it) }
+            apply()
         }
     }
 }

--- a/structure.txt
+++ b/structure.txt
@@ -8,6 +8,7 @@
         - AndroidManifest.xml
         [DIR] java/
               [DIR] hotspot_bypass_vpn/
+                - BootReceiver.kt
                 - DebugUtils.kt
                 - Dnscache.kt
                 - HostService.kt

--- a/windows_app/PhoneProxyManager.py
+++ b/windows_app/PhoneProxyManager.py
@@ -136,20 +136,25 @@ class TunManager:
     def start(self):
         t2s_exe = self._check_dependencies()
         
+        # FIX 1: Clean up any zombie routes from a previous crashed session
+        self.log("Cleaning up old routing states...")
+        subprocess.run(["route", "delete", "0.0.0.0", "mask", "128.0.0.0"], capture_output=True)
+        subprocess.run(["route", "delete", "128.0.0.0", "mask", "128.0.0.0"], capture_output=True)
+
         self.log("Starting VPN Interface...")
         cmd =[
             t2s_exe,
             "-device", "tun://PhoneVPN",
             "-proxy", f"socks5://{self.phone_ip}:{self.phone_port}",
-            "-loglevel", "error"
+            "-loglevel", "warning"  # Changed from error to warning for better debugging
         ]
 
-        cflags = 0x08000000 if IS_WINDOWS else 0 # Hide console window
+        cflags = 0x08000000 if IS_WINDOWS else 0
         self.process = subprocess.Popen(cmd, cwd=BIN_DIR, creationflags=cflags)
 
         self.log("Waiting for network adapter...")
         adapter_found = False
-        for _ in range(10):
+        for _ in range(15): # FIX 2: Increased wait time from 10 to 15 seconds
             res = subprocess.run(["netsh", "interface", "ipv4", "show", "interfaces"], capture_output=True, text=True)
             if "PhoneVPN" in res.stdout:
                 adapter_found = True
@@ -157,16 +162,26 @@ class TunManager:
             time.sleep(1)
             
         if not adapter_found:
-            raise Exception("Failed to create Virtual Adapter.")
+            self.stop() # Force cleanup
+            raise Exception("Failed to create Virtual Adapter. Check if Wintun driver installed properly.")
+
+        # FIX 3: Give Windows a moment to fully initialize the adapter before setting IPs
+        time.sleep(2.0) 
 
         self.log("Configuring IP & DNS routing...")
         subprocess.run(["netsh", "interface", "ip", "set", "address", "name=PhoneVPN", "static", "10.0.0.2", "255.255.255.0", "10.0.0.1"], capture_output=True)
         subprocess.run(["netsh", "interface", "ip", "set", "dns", "name=PhoneVPN", "static", "8.8.8.8"], capture_output=True)
 
+        # FIX 4: Give Windows a moment to apply the IP before modifying global routes
+        time.sleep(1.0)
+
         self.log("Applying Global Traffic Routes (0.0.0.0/1 & 128.0.0.0/1)...")
-        # Standard VPN trick: Two /1 routes override default gateway without deleting it
-        subprocess.run(["route", "add", "0.0.0.0", "mask", "128.0.0.0", "10.0.0.1", "metric", "1"], capture_output=True)
-        subprocess.run(["route", "add", "128.0.0.0", "mask", "128.0.0.0", "10.0.0.1", "metric", "1"], capture_output=True)
+        res1 = subprocess.run(["route", "add", "0.0.0.0", "mask", "128.0.0.0", "10.0.0.1", "metric", "1"], capture_output=True, text=True)
+        res2 = subprocess.run(["route", "add", "128.0.0.0", "mask", "128.0.0.0", "10.0.0.1", "metric", "1"], capture_output=True, text=True)
+        
+        if "failed" in res1.stderr.lower() or "failed" in res2.stderr.lower():
+            self.stop()
+            raise Exception("Failed to inject routing tables. Run as Administrator!")
 
     def stop(self):
         self.log("Restoring original routing...")
@@ -181,7 +196,9 @@ class TunManager:
             except subprocess.TimeoutExpired:
                 self.process.kill()
             self.process = None
-
+            
+        # FIX 5: Attempt to forcefully disable the interface so it doesn't get stuck
+        subprocess.run(["netsh", "interface", "set", "interface", "PhoneVPN", "disable"], capture_output=True)
 
 # ══════════════════════════════════════════════════════════════════════════════
 #  LOCAL HTTP→SOCKS5 BRIDGE
@@ -197,6 +214,10 @@ class HttpSocksBridge:
 
     def start(self):
         self._running = True
+        # FIX: Ensure old server is completely dead before starting thread
+        if self._server:
+            try: self._server.close()
+            except: pass
         threading.Thread(target=self._serve, daemon=True).start()
 
     def stop(self):
@@ -206,20 +227,29 @@ class HttpSocksBridge:
         except Exception: pass
 
     def _serve(self):
-        try:
-            self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            self._server.bind(("127.0.0.1", self.local_port))
-            self._server.listen(200)
-            self._server.settimeout(1.0)
-            while self._running:
-                try:
-                    conn, addr = self._server.accept()
-                    threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
-                except socket.timeout: continue
-                except Exception: break
-        except Exception as e:
-            self.log(f"[Bridge] Server error: {e}")
+        # FIX: Added a retry loop so if the port is stuck in TIME_WAIT, it tries again.
+        for attempt in range(5):
+            try:
+                self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                self._server.bind(("127.0.0.1", self.local_port))
+                self._server.listen(200)
+                self._server.settimeout(1.0)
+                break # Success! Break out of the retry loop
+            except OSError as e:
+                self.log(f"[Bridge] Port {self.local_port} in use. Retrying ({attempt+1}/5)...")
+                time.sleep(1)
+        else:
+            self.log(f"[Bridge] FATAL: Could not bind port {self.local_port}.")
+            self._running = False
+            return
+
+        while self._running:
+            try:
+                conn, addr = self._server.accept()
+                threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+            except socket.timeout: continue
+            except Exception: break
 
     def _handle(self, client: socket.socket):
         try:
@@ -554,10 +584,14 @@ class App(tk.Tk):
         self._set_status("Inactive", FG_DIM)
 
     def _on_close(self):
+        # FIX: Automatically clear proxy on exit, don't rely just on the prompt
+        if self._system_proxy_on:
+            WindowsProxyManager.clear_proxy()
+            
         if self._tun_mgr or self._bridge or self._system_proxy_on:
             if messagebox.askyesno("Quit", "Connection is still active. Stop and exit?"):
                 self._do_stop()
-                time.sleep(0.5)
+                time.sleep(1.0) # Give it time to delete routes
                 self.destroy()
         else:
             self.destroy()


### PR DESCRIPTION
…ability

This commit introduces several reliability improvements, including boot persistence, service auto-restart on app swipe, and enhanced stability for the Windows-side routing logic.

- **Android Service Reliability & Persistence:**
    - **`MyVpnServiceTun2Socks`:** Now runs in a separate `:vpn` process. Added `WakeLock` and `WifiLock` to prevent the system from killing the connection during sleep.
    - **Auto-Restart:** Both `HostService` and `MyVpnServiceTun2Socks` now use `AlarmManager` to schedule an immediate restart if the app is swiped away from the recent tasks list.
    - **`BootReceiver`:** Introduced a new broadcast receiver to automatically restart services after a device reboot based on saved preferences.
    - **`MainActivity`:** Implemented `saveServiceState` using `SharedPreferences` to track service status. Added a check for battery optimization bypass before starting the VPN.

- **Windows Proxy Manager Enhancements:**
    - **Routing Fixes:** Added cleanup logic to delete zombie routes (0.0.0.0/1, 128.0.0.0/1) before starting a new session. Added a fallback to forcefully disable the "PhoneVPN" interface on stop.
    - **Race Condition Mitigation:** Increased wait times for adapter initialization and added delays between setting IP addresses and modifying global routes.
    - **HTTP Bridge:** Added a retry loop for the local bridge to handle ports stuck in `TIME_WAIT`. Ensure old server instances are closed before starting new ones.
    - **Permission Handling:** Added explicit checks for routing table injection failures to alert users to run as Administrator.

- **Configuration:**
    - Updated `AndroidManifest.xml` to include the new `BootReceiver` and process isolation for the VPN service.
    - Switched `Tun2Socks` log level from `error` to `warning` for better troubleshooting.